### PR TITLE
(maint) Limit import of rbeapi to systems that support it

### DIFF
--- a/lib/puppet_x/net_dev/eos_api.rb
+++ b/lib/puppet_x/net_dev/eos_api.rb
@@ -29,7 +29,7 @@
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
 # IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-require 'rbeapi/client'
+require 'rbeapi/client' if Puppet.features.rbeapi?
 
 ##
 # PuppetX namespace


### PR DESCRIPTION
Previously the module was always attempting to load rbeapi even if hosted on a non EOS system.  This commit limits that behavior.

```
root@nxos-demo-2#puppet resource ntp_config
Error: Could not autoload puppet/provider/ntp_config/eos: cannot load such file -- rbeapi/client
Error: Could not autoload puppet/type/ntp_config: Could not autoload puppet/provider/ntp_config/eos: cannot load such file -- rbeapi/client
Error: Could not run: Could not autoload puppet/type/ntp_config: Could not autoload puppet/provider/ntp_config/eos: cannot load such file -- rbeapi/client
```