### PR TITLE
(NETDEV-29) Enhance netdev NTP providers

### DIFF
--- a/lib/puppet/provider/ntp_auth_key/eos.rb
+++ b/lib/puppet/provider/ntp_auth_key/eos.rb
@@ -1,0 +1,77 @@
+# encoding: utf-8
+
+require 'puppet/type'
+
+begin
+  require 'puppet_x/net_dev/eos_api'
+rescue LoadError => detail
+  require 'pathname' # JJM WORK_AROUND #14073
+  module_base = Pathname.new(__FILE__).dirname
+  require module_base + '../../../' + 'puppet_x/net_dev/eos_api'
+end
+
+Puppet::Type.type(:ntp_auth_key).provide(:eos) do
+  confine operatingsystem: [:AristaEOS] unless ENV['RBEAPI_CONNECTION']
+  confine feature: :rbeapi
+
+  # Create methods that set the @property_hash for the #flush method
+  mk_resource_methods
+
+  NTP_AUTH_KEY_PROPS = [
+    :algorithm,
+    :mode,
+    :password
+  ]
+
+  # Mix in the api as instance methods
+  include PuppetX::NetDev::EosApi
+
+  # Mix in the api as class methods
+  extend PuppetX::NetDev::EosApi
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def self.instances
+    result = node.api('ntp').get
+    result[:auth_keys].map do |key, attrs|
+      provider_hash = { name: key.to_s, ensure: :present }
+      provider_hash[:algorithm] = attrs[:algorithm]
+      provider_hash[:mode] = attrs[:mode]
+      provider_hash[:password] = attrs[:password]
+      new(provider_hash)
+    end
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def flush
+    opts = { key: resource[:name] }
+    opts[:enable] = false if @property_flush[:ensure] == :absent
+    NTP_AUTH_KEY_PROPS.each do |prop|
+      next unless @resource[prop]
+      opts[prop] = @resource[prop].to_s
+      @property_hash[prop] = @resource[prop]
+    end
+
+    output = node.api('ntp').set_authentication_key(opts)
+    if output == true
+      @property_hash[:name] = resource[:name]
+      @property_hash[:ensure] = @property_flush[:ensure]
+    else
+      raise Puppet::Error, "Unable to set #{resource}"
+    end
+  end
+end

--- a/lib/puppet/provider/ntp_config/eos.rb
+++ b/lib/puppet/provider/ntp_config/eos.rb
@@ -26,13 +26,27 @@ Puppet::Type.type(:ntp_config).provide(:eos) do
   def self.instances
     result = node.api('ntp').get
     provider_hash = { name: 'settings', ensure: :present }
+    provider_hash[:authenticate] = result[:authenticate].to_s.to_sym
     provider_hash[:source_interface] = result[:source_interface]
+    provider_hash[:trusted_key] = [result[:trusted_key]]
     [new(provider_hash)]
+  end
+
+  def authenticate=(value)
+    val = value == :true
+    node.api('ntp').set_authenticate(enable: val)
+    @property_hash[:authenticate] = val
   end
 
   def source_interface=(val)
     node.api('ntp').set_source_interface(value: val)
     @property_hash[:source_interface] = val
+  end
+
+  def trusted_key=(val)
+    node.api('ntp').set_trusted_key(default: true)
+    node.api('ntp').set_trusted_key(value: val[0])
+    @property_hash[:trusted_key] = val
   end
 
   def exists?

--- a/lib/puppet/provider/ntp_server/eos.rb
+++ b/lib/puppet/provider/ntp_server/eos.rb
@@ -17,39 +17,70 @@ Puppet::Type.type(:ntp_server).provide(:eos) do
   # Create methods that set the @property_hash for the #flush method
   mk_resource_methods
 
+  NTP_SERVER_PROPS = [
+    :key,
+    :prefer,
+    :maxpoll,
+    :minpoll,
+    :source_interface,
+    :vrf
+  ]
+
   # Mix in the api as instance methods
   include PuppetX::NetDev::EosApi
 
   # Mix in the api as class methods
   extend PuppetX::NetDev::EosApi
 
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
   def self.instances
     result = node.api('ntp').get
     result[:servers].map do |srv, attrs|
       provider_hash = { name: srv, ensure: :present }
+      provider_hash[:key] = attrs[:key]
+      provider_hash[:maxpoll] = attrs[:maxpoll]
+      provider_hash[:minpoll] = attrs[:minpoll]
       provider_hash[:prefer] = attrs[:prefer].to_s.to_sym
+      provider_hash[:source_interface] = attrs[:source_interface]
+      provider_hash[:vrf] = attrs[:vrf]
       new(provider_hash)
     end
   end
 
   def create
-    prefer = resource[:prefer] == :true
-    node.api('ntp').add_server(resource[:name], prefer)
-    @property_hash = { name: resource[:name], ensure: :present }
+    @property_flush[:ensure] = :present
   end
 
   def destroy
-    node.api('ntp').remove_server(resource[:name])
     @property_hash = { name: resource[:name], ensure: :absent }
-  end
-
-  def prefer=(value)
-    val = value == :true
-    node.api('ntp').set_prefer(resource[:name], val)
-    @property_hash[:prefer] = value
   end
 
   def exists?
     @property_hash[:ensure] == :present
+  end
+
+  def flush
+    if @property_hash[:ensure] == :absent
+      node.api('ntp').remove_server(resource[:name], resource[:vrf])
+    else
+      opts = {}
+      NTP_SERVER_PROPS.each do |prop|
+        next unless @resource[prop]
+        opts[prop] = @resource[prop].to_s
+        @property_hash[prop] = @resource[prop]
+      end
+
+      output = node.api('ntp').add_server(resource[:name], false, opts)
+      if output == true
+        @property_hash[:name] = resource[:name]
+        @property_hash[:ensure] = :present
+      else
+        raise Puppet::Error, "Unable to set #{resource}"
+      end
+    end
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-netdev_stdlib",
-      "version_range": ">= 0.10.0"
+      "version_range": ">= 0.12.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/fixtures/fixture_ntp.yaml
+++ b/spec/fixtures/fixture_ntp.yaml
@@ -1,5 +1,17 @@
 ---
+:authenticate: false
+:auth_keys:
+  1:
+    :algorithm: md5
+    :mode: 7
+    :password: 06120A3258
 :source_interface: Loopback0
 :servers:
   1.2.3.4:
+    :key: 1
+    :maxpoll: 8
+    :minpoll: 5
     :prefer: true
+    :source_interface: Ethernet1
+    :vrf: test
+:trusted_key: '1,5-70'


### PR DESCRIPTION
This commit enhances the existing ntp_config and ntp_server providers
and adds ntp_auth_key as specified in puppetlabs/netdev_stdlib#21

ntp_config
 - authenticate
 - trusted_key

ntp_server
 - key
 - maxpoll
 - minpoll
 - source_interface
 - vrf

ntp_auth_key
  - key
  - algorithm
  - mode
  - password